### PR TITLE
Valetudo > 2021.01.0b0 compatibility

### DIFF
--- a/lib/MqttClient.js
+++ b/lib/MqttClient.js
@@ -85,7 +85,15 @@ MqttClient.prototype.connect = function() {
             try {
                 this.updateMapTopic(JSON.parse(message));
             } catch(e) {
-                console.error(e);
+                try {
+                    this.updateMapTopic(JSON.parse(zlib.inflate(message)));
+                } catch(e) {
+                    try {
+                        this.updateMapTopic(JSON.parse(zlib.inflate(Buffer.from(message, "base64"))));
+                    } catch(e) {
+                        console.error(e);
+                    }
+                }
             }
         });
 


### PR DESCRIPTION
Starting with version 2021.01.0b0 valetudo deflates the JSON map data and allows for base64 encoding.
With this change we try to inflate or base64 decode and then inflate in case that JSON parsing fails.
The way this is done is not beautiful but the least invasive as no config changes are required.